### PR TITLE
fix: redirect page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,5 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import { memo, useEffect } from "react";
-
-export default memo(function () {
-  useEffect(() => {
-    window.location.href = "/home";
-  });
-
-  return null;
-});
+export default function RedirectPage() {
+  return redirect('/home');
+};


### PR DESCRIPTION
Simplify redirect page.

Unnecessary render on the client by making use of the `redirect` function provided by `next/navigation`.