### PR TITLE
fix: refactor analytics

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,13 +1,7 @@
-"use client";
-
-import { memo } from "react";
 import { DocumentsManager } from "@/client";
-import { useAnalytics } from "@/client/components";
 
-export default memo(function () {
-  useAnalytics();
-
+export default function Admin() {
   return (
     <DocumentsManager />
   );
-});
+};

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,13 +1,7 @@
-"use client";
-
-import { memo } from "react";
-import { useAnalytics } from "@/client/components";
 import { Home } from "@/client";
 
-export default memo(function () {
-  useAnalytics();
-
+export default function HomePage() {
   return (
     <Home />
   );
-});
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,10 @@
-import React, { memo } from "react";
 import { Inter } from "next/font/google";
 import type { Metadata } from "next";
 import { cn } from "@/client/components/common/utils";
 import { PRODUCT_DESCRIPTION } from "@/client/components/common/constants";
 import { SessionProvider } from "@/client/components/common/providers/session-provider";
 import "./globals.css";
+import Analytics from "@/client/components/common/analytics";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
   description: PRODUCT_DESCRIPTION,
 };
 
-export default memo(function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
@@ -23,8 +23,9 @@ export default memo(function RootLayout({
       <body className={cn(inter.className, "leading-relaxed text-base")}>
         <SessionProvider>
           {children}
+          <Analytics />
         </SessionProvider>
       </body>
     </html>
   );
-});
+};

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,11 +1,7 @@
-"use client";
-
-import React, { memo } from "react";
 import { LoginView } from "@/client";
-import { Header, useAnalytics } from "@/client/components";
+import { Header } from "@/client/components";
 
-export default memo(function () {
-  useAnalytics();
+export default function LoginPage() {
 
   return (
     <main className="bg-grid flex flex-col justify-center min-h-screen">
@@ -19,4 +15,4 @@ export default memo(function () {
       </div>
     </main>
   );
-});
+};

--- a/src/client/components/common/analytics/index.tsx
+++ b/src/client/components/common/analytics/index.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import useAnalytics from "./use-analytics";
+
+export default function Analytics() {
+  useAnalytics();
+  return null;
+}

--- a/src/client/components/index.tsx
+++ b/src/client/components/index.tsx
@@ -18,4 +18,3 @@ export { DocSearch };
 export { PoweredBy };
 export { ErrorMessage };
 export { ErrorToast };
-export { useAnalytics };


### PR DESCRIPTION
Refactor the `useAnalytics` hook to be called once in the `Layout.tsx` (#6).

The `useAnalytics` export in [src/client/components/index.tsx](https://github.com/GetWorkTools/support-docs-ai/compare/main...leomosley:support-docs-ai:patch-1?expand=1#diff-8a432461db70aca8018947331a7495d12d86d6afe0dc18c29ec8c5fb4210189d) has been removed as it was causing issues with RSC as it was being exported from a .tsx file so was expecting the use of the `"use client"` directive.

Also removed uneeded memoization in the `page.tsx`'s and `Layout.tsx` as they are now server components that are not re-rendered on  client. 

